### PR TITLE
Comments were as though key size was given in bits, not in bytes. The…

### DIFF
--- a/Sources/aes.c
+++ b/Sources/aes.c
@@ -147,6 +147,8 @@ void aes_init_keygen_tables( void )
     int pow[256];
     int log[256];
 
+    if (aes_tables_inited) return;
+
     // fill the 'pow' and 'log' tables over GF(2^8)
     for( i = 0, x = 1; i < 256; i++ )   {
         pow[i] = x;
@@ -281,6 +283,9 @@ int aes_set_encryption_key( aes_context *ctx,
                 RK[15] = RK[7] ^ RK[14];
             }
             break;
+
+	default:
+	    return -1;
     }
     return( 0 );
 }
@@ -348,7 +353,7 @@ int aes_setkey( aes_context *ctx,   // AES context provided by our caller
     // system-specific mutexes and init the AES key generation tables on
     // demand, or ask the developer to simply call "gcm_initialize" once during
     // application startup before threading begins. That's what we choose.
-    if( !aes_tables_inited ) return ( 0 );  // fail the call when not inited.
+    if( !aes_tables_inited ) return ( -1 );  // fail the call when not inited.
     
     ctx->mode = mode;       // capture the key type we're creating
     ctx->rk = ctx->buf;     // initialize our round key pointer
@@ -358,6 +363,7 @@ int aes_setkey( aes_context *ctx,   // AES context provided by our caller
         case 16: ctx->rounds = 10; break;   // 16-byte, 128-bit key
         case 24: ctx->rounds = 12; break;   // 24-byte, 192-bit key
         case 32: ctx->rounds = 14; break;   // 32-byte, 256-bit key
+	default: return(-1);
     }
 
 #if AES_DECRYPTION

--- a/Sources/aes.h
+++ b/Sources/aes.h
@@ -66,7 +66,8 @@ typedef struct {
 int aes_setkey( aes_context *ctx,       // pointer to context
                 int mode,               // 1 or 0 for Encrypt/Decrypt
                 const uchar *key,       // AES input key
-                uint keysize );         // 128, 192 or 256 bits
+                uint keysize );         // size in bytes (must be 16, 24, 32 for
+		                        // 128, 192 or 256-bit keys respectively)
                                         // returns 0 for success
 
 /******************************************************************************

--- a/Sources/gcm.c
+++ b/Sources/gcm.c
@@ -173,7 +173,8 @@ static void gcm_mult( gcm_context *ctx,     // pointer to established context
  ******************************************************************************/
 int gcm_setkey( gcm_context *ctx,   // pointer to caller-provided gcm context
                 const uchar *key,   // pointer to the AES encryption key
-                const uint keysize) // must be 128, 192 or 256
+                const uint keysize) // size in bytes (must be 16, 24, 32 for
+		                    // 128, 192 or 256-bit keys respectively)
 {
     int ret, i, j;
     uint64_t hi, lo;

--- a/Sources/gcm.h
+++ b/Sources/gcm.h
@@ -65,7 +65,8 @@ int gcm_initialize( void );
  ******************************************************************************/
 int gcm_setkey( gcm_context *ctx,   // caller-provided context ptr
                 const uchar *key,   // pointer to cipher key
-                const uint keysize  // must be 128, 192 or 256
+                const uint keysize  // size in bytes (must be 16, 24, 32 for
+		                    // 128, 192 or 256-bit keys respectively)
 ); // returns 0 for success
 
 
@@ -88,7 +89,7 @@ int gcm_setkey( gcm_context *ctx,   // caller-provided context ptr
  ******************************************************************************/
 int gcm_crypt_and_tag(
         gcm_context *ctx,       // gcm context with key already setup
-        int mode,               // cipher direction: GCM_ENCRYPT or GCM_DECRYPT
+        int mode,               // cipher direction: ENCRYPT (1) or DECRYPT (0)
         const uchar *iv,        // pointer to the 12-byte initialization vector
         size_t iv_len,          // byte length if the IV. should always be 12
         const uchar *add,       // pointer to the non-ciphered additional data
@@ -134,7 +135,7 @@ int gcm_auth_decrypt(
  *
  ******************************************************************************/
 int gcm_start( gcm_context *ctx,    // pointer to user-provided GCM context
-               int mode,            // GCM_ENCRYPT or GCM_DECRYPT
+               int mode,            // ENCRYPT (1) or DECRYPT (0)
                const uchar *iv,     // pointer to initialization vector
                size_t iv_len,       // IV length in bytes (should == 12)
                const uchar *add,    // pointer to additional AEAD data (NULL if none)


### PR DESCRIPTION
Comments were as though key size was given in bits, not in bytes. There were no checks on key size. This produce incorrect output data without returning an error. Constants GCM_ENCRYPT and GCM_DECRYPT were not defined, albeit mentioned in comments. A set key function returned 0 rather then -1 to indicate error when no tables were initialized.