### PR TITLE
Fixed a bug that did not allow inplace encryption or decryption 

### DIFF
--- a/Sources/gcm.c
+++ b/Sources/gcm.c
@@ -338,14 +338,31 @@ int gcm_update( gcm_context *ctx,       // pointer to user-provided GCM context
             return( ret );
 
         // encrypt or decrypt the input to the output
-        for( i = 0; i < use_len; i++ ) {
-            // XOR the cipher's ouptut vector (ectr) with our input
-            output[i] = (uchar) ( ectr[i] ^ input[i] );
-            // now we mix in our data into the authentication hash.
-            // if we're ENcrypting we XOR in the post-XOR (output) results,
-            // but if we're DEcrypting we XOR in the input data
-            if( ctx->mode == ENCRYPT )  ctx->buf[i] ^= output[i];
-            else                        ctx->buf[i] ^= input[i];
+        if( ctx->mode == ENCRYPT )  
+        {
+             for( i = 0; i < use_len; i++ ) {
+                // XOR the cipher's ouptut vector (ectr) with our input
+                output[i] = (uchar) ( ectr[i] ^ input[i] );
+                // now we mix in our data into the authentication hash.
+                // if we're ENcrypting we XOR in the post-XOR (output) 
+                // results, but if we're DEcrypting we XOR in the input 
+                // data
+                ctx->buf[i] ^= output[i];
+            }
+        }
+            else                        
+        {
+            for( i = 0; i < use_len; i++ ) {
+                // but if we're DEcrypting we XOR in the input data first, 
+                // i.e. before saving to ouput data, otherwise if the input 
+                // and output buffer are the same (inplace decryption) we 
+                // would not get the correct auth tag
+
+       	        ctx->buf[i] ^= input[i];
+
+                // XOR the cipher's ouptut vector (ectr) with our input
+                output[i] = (uchar) ( ectr[i] ^ input[i] );
+             }
         }
         gcm_mult( ctx, ctx->buf, ctx->buf );    // perform a GHASH operation
 


### PR DESCRIPTION
Fixed a bug that did not allow in-place update of the data. Previously, it was not possible to use the library in such a way to encrypt or decrypt the data properly in-place, i.e. when the pointer to the input and output buffer pointed to the same memory. Also, made small speed improvement because the mode ENCRYPT/DECRYPT is checked just once, not on each byte. We have successfully implemented that change already in our application a few months ago and it worked very well. I mean - very well tested! Thank you very much again for your software.